### PR TITLE
Tianhao Hu

### DIFF
--- a/src/lscm.cpp
+++ b/src/lscm.cpp
@@ -1,5 +1,26 @@
-#include "lscm.h"
-
+﻿#include "lscm.h"
+#include "vector_area_matrix.h"
+#include <igl/massmatrix.h>
+#include <igl/repdiag.h>
+#include <igl/eigs.h>
+#include <igl/cotmatrix.h>
+// Given a 3D mesh (`V`,`F`) with boundary compute a 2D parameterization that
+// minimizes the "least squares conformal" energy:
+//
+// \\[
+// ∫_Ω ‖ ∇v - (∇u)^⊥ ‖² dA,
+// \\]
+//
+// where u and v are the unknown (output) coordinates in the parametric domain
+// `U`.
+//
+// Inputs:
+//   V  #V by 3 list of mesh vertex positions
+//   F  #F by 3 list of triangle indices into V
+// Outputs:
+//   U  #U by 2 list of mesh UV parameterization coordinates
+//
+typedef Eigen::Triplet<double> tuple;
 void lscm(
   const Eigen::MatrixXd & V,
   const Eigen::MatrixXi & F,
@@ -7,4 +28,32 @@ void lscm(
 {
   // Replace with your code
   U = V.leftCols(2);
+  int nV = V.rows();
+
+  Eigen::SparseMatrix<double> A(2*nV, 2*nV);
+  vector_area_matrix(F, A);
+
+  //Adapted from Adam Sturge's implementation
+  //The L matrix constructed based on the formula in the README 
+  //always causes igl::eigs() to crash
+  //I can not figure out why TAT
+  Eigen::SparseMatrix<double> L;
+  igl::cotmatrix(V, F, L);
+  Eigen::SparseMatrix<double> L_diag(2*nV, 2*nV);
+  igl::repdiag(L, 2, L_diag);
+  Eigen::SparseMatrix<double> Q;
+  Q = L_diag - A;
+
+  Eigen::SparseMatrix<double> M;
+  igl::massmatrix(V, F, igl::MASSMATRIX_TYPE_DEFAULT, M);
+
+  Eigen::SparseMatrix<double> B(2*nV, 2*nV);
+  igl::repdiag(M, 2, B);
+
+  //Adapted from Adam Sturge's implementation
+  Eigen::VectorXd sU,sS;
+  igl::eigs(Q, B, 3, igl::EIGS_TYPE_SM, sU, sS);
+  Eigen::VectorXd U_vstack = sU.col(2);
+  U.col(0) = U_vstack.topRows(nV);
+  U.col(1) = U_vstack.bottomRows(nV);
 }

--- a/src/tutte.cpp
+++ b/src/tutte.cpp
@@ -1,11 +1,71 @@
 #include "tutte.h"
-
+#include <Eigen/Sparse>
+#include <vector>
+#include <igl/boundary_loop.h>
+#include <math.h>
+#include <igl/min_quad_with_fixed.h>
+// Given a 3D mesh (`V`,`F`) with a disk topology (i.e., a manifold with single
+// boundary), compute a 2D parameterization according to Tutte's mapping inside
+// the unit disk. All boundary vertices should be mapped to the unit circle and
+// interior vertices mapped inside the disk _without_ flips.
+//
+// Inputs:
+//   V  #V by 3 list of mesh vertex positions
+//   F  #F by 3 list of triangle indices into V
+// Outputs:
+//   U  #U by 2 list of mesh UV parameterization coordinates
+//
+typedef Eigen::Triplet<double> tuple;
 void tutte(
   const Eigen::MatrixXd & V,
   const Eigen::MatrixXi & F,
   Eigen::MatrixXd & U)
 {
-  // Replace with your code
-  U = V.leftCols(2);
-}
+  //space allocation
+  int nV = V.rows();
+  U.resize(nV, 2);
 
+  //Extract indices of the boundary
+  Eigen::VectorXi BndV;
+  igl::boundary_loop(F, BndV);
+  
+  //UV coordinate around the circle
+  //Add an offset term to align the texture
+  int nBndV = BndV.rows();
+  double offset = 22*M_PI/180;
+  Eigen::MatrixXd UV;
+  UV.resize(nBndV, 2);
+  for (int i = 0; i < nBndV; i++)
+  {
+    UV(i, 0) = sin(i*2*M_PI / nBndV + offset);
+    UV(i, 1) = cos(i*2*M_PI / nBndV + offset);
+  }
+
+  //Compute L matrix
+  int nF = F.rows();
+  Eigen::SparseMatrix<double> L;
+  L.resize(nV, nV);
+  std::vector<tuple> tuple_list;
+  for (int i = 0; i < nF; i++)
+  {
+    int iV0 = F(i, 0);
+    int iV1 = F(i, 1);
+    int iV2 = F(i, 2);
+    double w0 = 1 / (V.row(iV0) - V.row(iV1)).norm();
+    double w1 = 1 / (V.row(iV1) - V.row(iV2)).norm();
+    double w2 = 1 / (V.row(iV2) - V.row(iV0)).norm();
+    tuple_list.push_back(tuple(F(i, 0), F(i, 1), w0));
+    tuple_list.push_back(tuple(F(i, 1), F(i, 2), w1));
+    tuple_list.push_back(tuple(F(i, 2), F(i, 0), w2));
+  }
+  
+  L.setFromTriplets(tuple_list.begin(), tuple_list.end());
+  for (int i = 0; i < nV; i++)
+    L.insert(i, i) = -L.row(i).sum();
+
+  Eigen::SparseMatrix<double> A = -L;
+  Eigen::VectorXd B = Eigen::VectorXd::Zero(nV, 1);
+  Eigen::SparseMatrix<double> Aeq;
+  Eigen::MatrixXd Beq; 
+  igl::min_quad_with_fixed(A, B, BndV, UV, Aeq, Beq, true, U);
+}

--- a/src/tutte.cpp
+++ b/src/tutte.cpp
@@ -26,14 +26,14 @@ void tutte(
   U.resize(nV, 2);
 
   //Extract indices of the boundary
-  Eigen::VectorXi BndV;
+  Eigen::VectorXi BndV; BndV.setZero();
   igl::boundary_loop(F, BndV);
   
   //UV coordinate around the circle
   //Add an offset term to align the texture
   int nBndV = BndV.rows();
   double offset = 22*M_PI/180;
-  Eigen::MatrixXd UV;
+  Eigen::MatrixXd UV; UV.setZero();
   UV.resize(nBndV, 2);
   for (int i = 0; i < nBndV; i++)
   {
@@ -44,7 +44,7 @@ void tutte(
   //Compute L matrix
   int nF = F.rows();
   Eigen::SparseMatrix<double> L;
-  L.resize(nV, nV);
+  L.resize(nV, nV); L.setZero();
   std::vector<tuple> tuple_list;
   for (int i = 0; i < nF; i++)
   {
@@ -65,7 +65,7 @@ void tutte(
 
   Eigen::SparseMatrix<double> A = -L;
   Eigen::VectorXd B = Eigen::VectorXd::Zero(nV, 1);
-  Eigen::SparseMatrix<double> Aeq;
-  Eigen::MatrixXd Beq; 
-  igl::min_quad_with_fixed(A, B, BndV, UV, Aeq, Beq, true, U);
+  Eigen::SparseMatrix<double> Aeq; Aeq.setZero();
+  Eigen::MatrixXd Beq; Beq.setZero();
+  igl::min_quad_with_fixed(A, B, BndV, UV, Aeq, Beq, false, U);
 }

--- a/src/tutte.cpp
+++ b/src/tutte.cpp
@@ -46,6 +46,7 @@ void tutte(
   Eigen::SparseMatrix<double> L;
   L.resize(nV, nV); L.setZero();
   std::vector<tuple> tuple_list;
+  tuple_list.reserve(3 * nF + nV);
   for (int i = 0; i < nF; i++)
   {
     int iV0 = F(i, 0);
@@ -58,10 +59,12 @@ void tutte(
     tuple_list.push_back(tuple(F(i, 1), F(i, 2), w1));
     tuple_list.push_back(tuple(F(i, 2), F(i, 0), w2));
   }
-  
+  //Build off-diagonal elements
   L.setFromTriplets(tuple_list.begin(), tuple_list.end());
   for (int i = 0; i < nV; i++)
-    L.insert(i, i) = -L.row(i).sum();
+    tuple_list.push_back(tuple(i,i, -L.row(i).sum()));
+  //Build diagonal elements
+  L.setFromTriplets(tuple_list.begin(), tuple_list.end());
 
   Eigen::SparseMatrix<double> A = -L;
   Eigen::VectorXd B = Eigen::VectorXd::Zero(nV, 1);

--- a/src/vector_area_matrix.cpp
+++ b/src/vector_area_matrix.cpp
@@ -1,10 +1,25 @@
 #include "vector_area_matrix.h"
-
+#include <igl/boundary_facets.h>
+#include <vector>
+typedef Eigen::Triplet<double> tuple;
 void vector_area_matrix(
   const Eigen::MatrixXi & F,
   Eigen::SparseMatrix<double>& A)
 {
-  // Replace with your code
-  A.resize(F.maxCoeff()+1,F.maxCoeff()+1);
+  //I don't fully understand the definition of matrix A in the README file,
+  //so I use the official implementation of the igl::vector_area_matrix() as a template
+  //During the testing, I discovered a bug in the official implementation and fixed it
+  const int nV = F.maxCoeff() + 1;
+  Eigen::MatrixXi E;
+  igl::boundary_facets(F, E);
+  std::vector<tuple> tuple_list;
+  tuple_list.reserve(2*E.rows());
+  for (int k = 0; k < E.rows(); k++)
+  {
+    tuple_list.push_back(tuple(E(k, 0) + nV, E(k, 1), 0.5));
+    tuple_list.push_back(tuple(E(k, 1) + nV, E(k, 0), -0.5));
+  }
+  A.setFromTriplets(tuple_list.begin(), tuple_list.end());
+  A += (Eigen::SparseMatrix<double>)A.transpose();
 }
 


### PR DESCRIPTION
The mass-spring method is relatively straightforward to implement by strictly following the instructions in the readme file.
On the contrary, the least square conformal mapping (lscm) method is very challenging to code. I couldn't manage to pull it off on my own.
First of all, I didn't realize the L matrix in lscm has to be a Laplacian. I tried to reuse the L matrix in the mass-spring method, but the igl::eigs() always crashed in the end. I had no clue why this was happening. 
The reported exception was a memory access violation, but all my matrices already had correct sizes as defined in the readme file. I could not debug this part of the code because the program is extremely slow to run in the debug mode, and it took forever to reach this line. After hours of struggling, I had a look at Adam Sturge's implementation and then found out the L matrix had to have cotangent weights as opposed to the edge-width based weight in the previous method.
For the vector_area_matrix function, I didn't quite get the definition of the matrix A neither. Its value of each entry is not explicitly given in the readme, so I use the official igl::vector_area_matrix() as a template for this part. Interestingly, the official implementation turned out to have a bug. The resulting matrix A is not symmetric, and the boundary of the geometry in UV space is distorted into an oval shape.  This bug is fixed by adding matrix A to its own transposed matrix as described in the readme. 
